### PR TITLE
Redirect root to `tsdws` path

### DIFF
--- a/docker/nginx/conf.d/default.conf
+++ b/docker/nginx/conf.d/default.conf
@@ -72,12 +72,25 @@ server {
 
   # Proxying to the application server
   ## API server
-  location / {
+
+  location = / {
+    return 301 $scheme://$host${request_uri}tsdws;
+  }
+
+  location /swagger {
     proxy_pass http://app;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+  }
+
+  location /tsdws {
+    proxy_pass http://app;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
   }
   
   location /grafana/ {


### PR DESCRIPTION
Redirect root location (`/`) to `/tsdws` subfolder, add missing location for `swagger` location also.